### PR TITLE
Fixed two small errors preventing the automated installation from working

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -13,6 +13,5 @@ test/test_matrix.lua
 test/test_fit.lua
 test/test_complex.lua
 doc/complex_changelog.txt
-doc/fit_changelog.txt
 doc/matrix_changelog.txt
 samples/fit.lua

--- a/README.txt
+++ b/README.txt
@@ -11,7 +11,8 @@ as well as the test suite.
 
 To install, copy matrix.lua and complex.lua into your LUA_PATH.  The
 modules can alternately be installed via LuaRocks ("luarocks install
-luamatrix").
+luamatrix"). Or, run "./util.mk; cd tmp/*; luarocks make" from a local
+clone.
 
 == Project Page ==
 

--- a/rockspec.in
+++ b/rockspec.in
@@ -26,7 +26,7 @@ build = {
          ["matrix"]  = "lua/matrix.lua",
       }
    },
-   copy_directories = {"doc", "samples", "tests"},
+   copy_directories = {"doc", "samples", "test"},
 }
 -- test: tests/test.lua
 -- _VERSION from lua/matrix.lua


### PR DESCRIPTION
`MANIFEST` included `doc/fit_changelog.txt`, which does not exist. Also, `rockspec.in` calls the `test` directory `tests`. The former caused `util.mk` to fail, the latter caused `luarocks make` to fail. This PR fixes those, and adds the now-working local luarocks installation method to the `README`.